### PR TITLE
correct links to worshop pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This website is made available to share information and resources about past and
 
 # Upcoming Events
 
-- [Workshop at DH 2024](./events/2024_DH_Workshop), 6 August 2024 (George Mason University, Arlington, VA, USA)
+- [Workshop at DH 2024](./_events/2024_DH_Workshop.md), 6 August 2024 (George Mason University, Arlington, VA, USA)
 
 # Past Events 
 
-- [DTS Hackathon](./events/2021-hackathon), 27 September - 8 October 2021 (Online)
-- [Text And APIs](./events/2019-hamburg), 15-16 July 2019, Hamburg, Germany
+- [DTS Hackathon](./_events/2021-hackathon.md), 27 September - 8 October 2021 (Online)
+- [Text And APIs](./_events/2019-hamburg.md), 15-16 July 2019, Hamburg, Germany


### PR DESCRIPTION
missing "_" and .md in path